### PR TITLE
feat: update with mise support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,12 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 2
+indent_style = tab
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,26 @@
-name: Build
+name: asdf
+
 on:
-  pull_request:
-    paths-ignore:
-      - "**.md"
   push:
-    paths-ignore:
-      - "**.md"
+    branches:
+      - master
+  pull_request:
   schedule:
-    - cron: "0 0 * * *" # daily at midnight
+    - cron: 0 0 * * 5
 
 jobs:
   plugin_test:
-    name: asdf plugin test
-    runs-on: macos-latest
+    name: asdf plugin test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: swiftformat --help
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,40 +1,24 @@
-name: Lint
+name: lint
+
 on:
-  pull_request:
-    paths-ignore:
-      - "**.md"
   push:
-    paths-ignore:
-      - "**.md"
-  schedule:
-    - cron: "0 0 * * *" # daily at midnight
+    branches:
+      - master
+  pull_request:
 
 jobs:
-  shellcheck:
-    name: shellcheck
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Update Shellcheck
-        run: |
-          sudo apt install xz-utils
-          scversion="stable"
-          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
-          sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
-          shellcheck --version
-      - name: Shellcheck
-        run: shellcheck -x bin/* -P lib/
+      - uses: actions/checkout@v4
+      - uses: asdf-vm/actions/install@v3
+      - run: scripts/lint.bash
 
-  shfmt:
-    runs-on: macos-latest
-
+  actionlint:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install shfmt
-        run: brew install shfmt
-
-      - name: Run shfmt
-        run: shfmt -d -i 2 -ci .
+      - uses: actions/checkout@v4
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.6.23
+        with:
+          args: -color

--- a/.github/workflows/test-mise.yml
+++ b/.github/workflows/test-mise.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           install: false
 
-      - run: mise exec asdf:https://github.com/younke/asdf-swiftformat@master -- swiftformat --help
+      - run: mise exec asdf:https://github.com/younke/asdf-swiftformat@latest -- swiftformat --help

--- a/.github/workflows/test-mise.yml
+++ b/.github/workflows/test-mise.yml
@@ -1,0 +1,33 @@
+name: mise
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: 0 0 * * 5
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  test:
+    name: mise test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      - run: mise exec asdf:https://github.com/younke/asdf-swiftformat@master -- swiftformat --help

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+shellcheck 0.9.0
+shfmt 3.6.0

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+mkdir -p "$ASDF_DOWNLOAD_PATH"
+
+binary_name="$(get_binary_name)"
+release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+
+download_release "$ASDF_INSTALL_VERSION" "$release_file"
+
+unzip -q "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+
+rm "$release_file"

--- a/bin/download
+++ b/bin/download
@@ -10,7 +10,6 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-binary_name="$(get_binary_name)"
 release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
 
 download_release "$ASDF_INSTALL_VERSION" "$release_file"

--- a/bin/install
+++ b/bin/install
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
 # shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=../lib/utils.bash
+. "${plugin_dir}/lib/utils.bash"
+
+curl_opts=(-sI)
+
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+# curl of REPO/releases/latest is expected to be a 302 to another URL
+# when no releases redirect_url="REPO/releases"
+# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
+redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
+version=
+printf "redirect url: %s\n" "$redirect_url" >&2
+if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
+	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
+else
+	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+fi
+
+printf "%s\n" "$version"

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
 # shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+source "${plugin_dir}/lib/utils.bash"
 
 list_all_versions | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -30,17 +30,25 @@ get_platform() {
 	esac
 }
 
-# Returns the binary name for the current platform
+# Returns the binary name for the current platform and architecture
 get_binary_name() {
-	local platform
+	local platform arch
 	platform="$(get_platform)"
+	arch="$(uname -m)"
 
 	case "$platform" in
 	macos)
 		echo "swiftformat"
 		;;
 	linux)
-		echo "swiftformat_linux"
+		case "$arch" in
+		aarch64)
+			echo "swiftformat_linux_aarch64"
+			;;
+		*)
+			echo "swiftformat_linux"
+			;;
+		esac
 		;;
 	esac
 }

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+shfmt --language-dialect bash --write \
+	./**/*

--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+shellcheck --shell=bash --external-sources \
+	bin/* --source-path=template/lib/ \
+	lib/* \
+	scripts/*
+
+shfmt --language-dialect bash --diff \
+	./**/*

--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 shellcheck --shell=bash --external-sources \
-	bin/* --source-path=template/lib/ \
+	bin/* --source-path=lib/ \
 	lib/* \
 	scripts/*
 


### PR DESCRIPTION
## Summary

Modernize plugin structure:

- Add `bin/download` script (separates download from install)
- Add `bin/latest-stable` script (enables `asdf latest swiftformat`)
- Add `scripts/lint.bash` and `scripts/format.bash` for local development
- Add `.tool-versions` to pin shellcheck/shfmt versions
- Add `.github/dependabot.yml` for automatic GH Actions updates
- Add `.github/workflows/test-mise.yml` for mise compatibility testing
- Add Linux ARM64 support (`swiftformat_linux_aarch64`)
- Update CI to test on both macOS and Linux
- Update GitHub Actions to latest versions (v3/v4)
- Add actionlint job to validate workflow files
- Switch to tab indentation (enforced by shfmt)
- Use `BASH_SOURCE[0]` pattern for reliable script sourcing
- Use `GITHUB_TOKEN` instead of `GITHUB_API_TOKEN`

## Supported Binaries

| Platform | Architecture | Binary |
|----------|--------------|--------|
| macOS | any | `swiftformat` |
| Linux | x86_64 | `swiftformat_linux` |
| Linux | aarch64 | `swiftformat_linux_aarch64` |

## Test plan

- [ ] `asdf plugin test swiftformat . "swiftformat --help"` on macOS
- [ ] `asdf plugin test swiftformat . "swiftformat --help"` on Linux x86_64
- [ ] `asdf latest swiftformat` returns latest version
- [ ] `scripts/lint.bash` passes
