### PR TITLE
docs(readme): update ci badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-# asdf-swiftformat ![Build](https://github.com/younke/asdf-swiftformat/workflows/Build/badge.svg) ![Lint](https://github.com/younke/asdf-swiftformat/workflows/Lint/badge.svg)
+# asdf-swiftformat
+
+[![asdf](https://github.com/younke/asdf-swiftformat/actions/workflows/build.yml/badge.svg)](https://github.com/younke/asdf-swiftformat/actions/workflows/build.yml) [![Lint](https://github.com/younke/asdf-swiftformat/actions/workflows/lint.yml/badge.svg)](https://github.com/younke/asdf-swiftformat/actions/workflows/lint.yml) [![mise](https://github.com/younke/asdf-swiftformat/actions/workflows/test-mise.yml/badge.svg)](https://github.com/younke/asdf-swiftformat/actions/workflows/test-mise.yml)
 
 [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) plugin for the [asdf version manager](https://asdf-vm.com).
 


### PR DESCRIPTION
## Summary

Update CI badges in README to use the new GitHub Actions badge format with clickable links.

- Replace inline badge syntax with proper markdown image links
- Add badge for mise compatibility testing workflow
- Improve badge layout by moving title to separate line

## Test plan

- [x] Verify badges render correctly in GitHub README preview
- [x] Confirm badge links point to correct workflow pages
